### PR TITLE
Make JULIA_HOME the default installation directory.

### DIFF
--- a/juliac.jl
+++ b/juliac.jl
@@ -37,12 +37,12 @@ function compile(julia_program_file, julia_install_path,
 end
 
 
-if length(ARGS) < 2
-    println("Usage: $(@__FILE__) <Julia Program file> <Julia installation Path> [Julia Package Directory]")
+if length(ARGS) < 1
+    println("Usage: $(@__FILE__) <Julia Program file> [Julia installation Path [Julia Package Directory]]")
     exit(1)
 end
 JULIA_PROGRAM_FILE = ARGS[1]
-JULIA_INSTALL_PATH = ARGS[2]
+JULIA_INSTALL_PATH = length(ARGS) > 1 ? ARGS[2] : dirname(JULIA_HOME)
 
 println("Program File : $JULIA_PROGRAM_FILE")
 println("Julia Install Path: $JULIA_INSTALL_PATH")


### PR DESCRIPTION
Handy when using the default installation of julia.