### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.dylib
 *.dll
 hello
+*.exe


### PR DESCRIPTION
* adds default for julia home
* uses `Libdl.dlext` for sys
Coincidentally addresses #7 #5 #6 

Doesnt't actually work: throws a linking error because of undefined reference to `julia_main`.
`@ccallable` probably doesn't emit the right intrinsics for windows.
cc @vtjnash @Keno 
