### PR TITLE
Add cpu-target option

### DIFF
--- a/juliac.jl
+++ b/juliac.jl
@@ -45,7 +45,7 @@ function main(args)
         "--target", "-t"
             help = "compilations target"
             arg_type = String
-            default = "x86-64"
+            default = "generic"
     end
 
     parsed_args = parse_args(args, s)
@@ -155,7 +155,8 @@ function julia_compile(julia_program, c_program=nothing, build_dir="builddir", v
                    "include(\"$julia_program\"); push!(Base.LOAD_CACHE_PATH, \"$julia_pkglibdir\"); empty!(Base.LOAD_CACHE_PATH)"`
         # set compilation target
         for i in eachindex(command.exec)
-            command.exec[i] = replace(command.exec[i], "x86-64", target)
+            cmd = command.exec[i]
+            startswith(cmd, "-C") && command.exec[i] = "-C$target"
         end
         if verbose
             println("Build object file \"$o_file\":\n$command")

--- a/juliac.jl
+++ b/juliac.jl
@@ -42,6 +42,10 @@ function main(args)
         "--clean", "-c"
             help = "delete builddir"
             action = :store_true
+        "--target", "-t"
+            help = "compilations target"
+            arg_type = String
+            default = "x86-64"
     end
 
     parsed_args = parse_args(args, s)
@@ -63,12 +67,13 @@ function main(args)
         parsed_args["shared"],
         parsed_args["executable"],
         parsed_args["julialibs"],
-        parsed_args["clean"]
+        parsed_args["clean"],
+        parsed_args["target"]
     )
 end
 
 function julia_compile(julia_program, c_program=nothing, build_dir="builddir", verbose=false, quiet=false,
-                       object=false, shared=false, executable=true, julialibs=true, clean=false)
+                       object=false, shared=false, executable=true, julialibs=true, clean=false, target="x86-64")
 
     if verbose && quiet
         verbose = false
@@ -148,6 +153,10 @@ function julia_compile(julia_program, c_program=nothing, build_dir="builddir", v
     if object || shared || executable
         command = `"$(Base.julia_cmd())" "--startup-file=no" "--output-o" "$o_file" "-e"
                    "include(\"$julia_program\"); push!(Base.LOAD_CACHE_PATH, \"$julia_pkglibdir\"); empty!(Base.LOAD_CACHE_PATH)"`
+        # set compilation target
+        for i in eachindex(command.exec)
+            command.exec[i] = replace(command.exec[i], "x86-64", target)
+        end
         if verbose
             println("Build object file \"$o_file\":\n$command")
         end


### PR DESCRIPTION
Adding this option and allowing to use target=`core-avx-i` was the only way I was able to make the script work in "Windows Server2012-R2 with Intel Xeon E5-2670 v2"

as mentioned in #39 