### PR TITLE
Added a --startup-file=no

### DIFF
--- a/juliac.jl
+++ b/juliac.jl
@@ -158,7 +158,7 @@ function julia_compile(julia_program, c_program=nothing, build_dir="builddir", v
     end
 
     if shared || executable
-        command = `$(Base.julia_cmd()) $(joinpath(dirname(JULIA_HOME), "share", "julia", "julia-config.jl"))`
+        command = `$(Base.julia_cmd()) --startup-file=no $(joinpath(dirname(JULIA_HOME), "share", "julia", "julia-config.jl"))`
         cflags = Base.shell_split(readstring(`$command --cflags`))
         ldflags = Base.shell_split(readstring(`$command --ldflags`))
         ldlibs = Base.shell_split(readstring(`$command --ldlibs`))


### PR DESCRIPTION
Otherwise the .juliarc.jl file might interfere, e.g. when printing something.