### PR TITLE
Avoid need to change program.c by providing lib name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,11 @@ script into object code, and then builds it into the system image
 specified by the `-J` switch. This prepares an object file, which is
 then linked into a shared library containing the system image and user
 code. A driver script such as the one in `program.c` can then be used to
-build a binary that runs the julia code. For now, the image file has
-to be changed in `program.c` to match the name of the shared library
-containing the compiled julia program.
+build a binary that runs the julia code.
 
 Instead of a driver script, the generated system image can be embedded
 into a larger program following the embedding examples and relevant
-sections in the Julia manual.
+sections in the Julia manual. Note that the name of the generated system image (`"libhello"` for `hello.jl`) is accessible from C in the preprocessor macro `JULIA_LIB_NAME`.
 
 With Julia 0.7, a single large binary can be created, which does not
 require the driver program to load the shared library. An example of

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ build a binary that runs the julia code.
 
 Instead of a driver script, the generated system image can be embedded
 into a larger program following the embedding examples and relevant
-sections in the Julia manual. Note that the name of the generated system image (`"libhello"` for `hello.jl`) is accessible from C in the preprocessor macro `JULIA_LIB_NAME`.
+sections in the Julia manual. Note that the name of the generated system image (`"libhello"` for `hello.jl`) is accessible from C in the preprocessor macro `JULIAC_PROGRAM_LIBNAME`.
 
 With Julia 0.7, a single large binary can be created, which does not
 require the driver program to load the shared library. An example of

--- a/juliac.jl
+++ b/juliac.jl
@@ -250,6 +250,7 @@ function julia_compile(julia_program, c_program=nothing, build_dir="builddir", v
     end
 
     if executable
+        push!(cflags, "-DJULIA_LIB_NAME=\"lib$julia_program_basename\"")
         command = `$cc -m64 -o $e_file $c_program $s_file $cflags $ldflags $ldlibs`
         if is_apple()
             command = `$command -Wl,-rpath,@executable_path`

--- a/juliac.jl
+++ b/juliac.jl
@@ -250,7 +250,7 @@ function julia_compile(julia_program, c_program=nothing, build_dir="builddir", v
     end
 
     if executable
-        push!(cflags, "-DJULIA_LIB_NAME=\"lib$julia_program_basename\"")
+        push!(cflags, "-DJULIAC_PROGRAM_LIBNAME=\"lib$julia_program_basename\"")
         command = `$cc -m64 -o $e_file $c_program $s_file $cflags $ldflags $ldlibs`
         if is_apple()
             command = `$command -Wl,-rpath,@executable_path`

--- a/program.c
+++ b/program.c
@@ -11,10 +11,6 @@
 #ifdef JULIA_DEFINE_FAST_TLS // only available in Julia 0.7+
 JULIA_DEFINE_FAST_TLS()
 #endif
-// TODO(nhdaly): Would a better name be JL_IMAGE_NAME?
-#ifndef JULIA_LIB_NAME // Should be specified by -DJULIA_LIB_NAME="libname"
-#define JULIA_LIB_NAME "libhello"
-#endif
 
 // Declare C prototype of a function defined in Julia
 extern void julia_main();
@@ -26,7 +22,8 @@ int main(int argc, char *argv[])
     // Initialize Julia
     uv_setup_args(argc, argv); // no-op on Windows
     libsupport_init();
-    jl_options.image_file = JULIA_LIB_NAME;
+    // JULIAC_PROGRAM_LIBNAME defined on command-line for compilation.
+    jl_options.image_file = JULIAC_PROGRAM_LIBNAME;
     julia_init(JL_IMAGE_JULIA_HOME);
 
     // Do some work

--- a/program.c
+++ b/program.c
@@ -11,6 +11,10 @@
 #ifdef JULIA_DEFINE_FAST_TLS // only available in Julia 0.7+
 JULIA_DEFINE_FAST_TLS()
 #endif
+// TODO(nhdaly): Would a better name be JL_IMAGE_NAME?
+#ifndef JULIA_LIB_NAME // Should be specified by -DJULIA_LIB_NAME="libname"
+#define JULIA_LIB_NAME "libhello"
+#endif
 
 // Declare C prototype of a function defined in Julia
 extern void julia_main();
@@ -22,7 +26,7 @@ int main(int argc, char *argv[])
     // Initialize Julia
     uv_setup_args(argc, argv); // no-op on Windows
     libsupport_init();
-    jl_options.image_file = "libhello";
+    jl_options.image_file = JULIA_LIB_NAME;
     julia_init(JL_IMAGE_JULIA_HOME);
 
     // Do some work

--- a/program2.c
+++ b/program2.c
@@ -41,7 +41,8 @@ int wmain(int argc, wchar_t *wargv[], wchar_t *envp[])
     // initialization
     libsupport_init();
     // jl_options.compile_enabled = JL_OPTIONS_COMPILE_OFF;
-    jl_options.image_file = JULIA_LIB_NAME;
+    // JULIAC_PROGRAM_LIBNAME defined on command-line for compilation.
+    jl_options.image_file = JULIAC_PROGRAM_LIBNAME;
     julia_init(JL_IMAGE_JULIA_HOME);
 
     // build arguments array: `String[ unsafe_string(argv[i]) for i in 1:argc ]`

--- a/program2.c
+++ b/program2.c
@@ -41,7 +41,7 @@ int wmain(int argc, wchar_t *wargv[], wchar_t *envp[])
     // initialization
     libsupport_init();
     // jl_options.compile_enabled = JL_OPTIONS_COMPILE_OFF;
-    jl_options.image_file = "libhello";
+    jl_options.image_file = JULIA_LIB_NAME;
     julia_init(JL_IMAGE_JULIA_HOME);
 
     // build arguments array: `String[ unsafe_string(argv[i]) for i in 1:argc ]`


### PR DESCRIPTION
Changes juliac.jl to provide the name of the created shared lib
("libhello") to the c preprocessor as a macro, via "-D".

This way you do not need to modify the provided program.c when compiling
a new julia program.

Addresses issue #3.