### PR TITLE
Add deprecation + merging notice to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## NOTE: This repository is deprecated. `juliac.jl` has been merged into [PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl). Please install that package to use `juliac.jl`.
+
+----------------------
+
 # Static Julia Compiler
 
 Building shared libraries and executables from Julia code.


### PR DESCRIPTION
Add a notice to the top of the README that this repository is deprecated in favor of [PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl). This repo has been merged into that package.